### PR TITLE
set script type correctly

### DIFF
--- a/collective/easyform/browser/modeleditor.pt
+++ b/collective/easyform/browser/modeleditor.pt
@@ -39,7 +39,7 @@
             </form>
             <div id="modelEditor" tal:content="view/modelSource" />
         </div>
-    <script>
+    <script type="text/javascript">
         // start with an editor that fits the viewport with room
         // to show the save button.
         jQuery(function ($) {


### PR DESCRIPTION
In a project we are moving all javascript tags/containers to the bottom of the page using Diazo. Since this one isn't correctly typed it will stick in the middle, but since everything all other real javascript is moved, jQuery will still be undefined.