### PR TITLE
Possible fix for missing mail address from registry #33

### DIFF
--- a/collective/easyform/actions.py
+++ b/collective/easyform/actions.py
@@ -35,10 +35,12 @@ from email.utils import formataddr
 from logging import getLogger
 from plone.namedfile.interfaces import INamedBlobFile
 from plone.namedfile.interfaces import INamedFile
+from plone.registry.interfaces import IRegistry
 from plone.supermodel.exportimport import BaseHandler
 from time import time
 from types import StringTypes
 from zope.component import queryUtility
+from zope.component import getUtility
 from zope.contenttype import guess_content_type
 from zope.interface import implements
 from zope.schema import Bool
@@ -248,6 +250,7 @@ class Mailer(Action):
         pprops = getToolByName(context, 'portal_properties')
         site_props = getToolByName(pprops, 'site_properties')
         portal = getToolByName(context, 'portal_url').getPortalObject()
+        registry = getUtility(IRegistry)
 
         # get Reply-To
         reply_addr = None
@@ -258,7 +261,8 @@ class Mailer(Action):
         from_addr = (
             from_addr or
             site_props.getProperty('email_from_address') or
-            portal.getProperty('email_from_address')
+            portal.getProperty('email_from_address') or 
+            registry.get('plone.email_from_address')
         )
 
         if hasattr(self, 'senderOverride') and self.senderOverride:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import os
 
-version = '1.0a3'
+version = '1.0a3gww1'
 
 setup(name='collective.easyform',
       version=version,

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import os
 
-version = '1.0a3gww1'
+version = '1.0a3'
 
 setup(name='collective.easyform',
       version=version,


### PR DESCRIPTION
Possible fix for missing email_from_address in Plone 5, also see issue #33 
